### PR TITLE
[LB-216]: Fix ENV Variables in Docker Compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -116,8 +116,8 @@ services:
       - 3000:3000
     expose:
       - 3000
-    depends_on:
-      - mongo
+    # depends_on:
+    #   - mongo
 
   # biap-igm-node-js:
   #   build:
@@ -189,7 +189,7 @@ services:
     container_name: bap-protocol-consumer
     depends_on:
       - rabbitmq
-      - mongo
+      # - mongo
     environment:
       ENV: ${PROTOCOL_ENV}
       RABBITMQ_HOST: ${RABBITMQ_HOST}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -99,7 +99,7 @@ services:
         BAP_PUBLIC_KEY: ${BAP_PUBLIC_KEY}
         BAP_UNIQUE_KEY_ID: ${BAP_UNIQUE_KEY_ID}
         PORT: 3000
-        NODE_DEV: dev
+        NODE_ENV: prod
         REGISTRY_BASE_URL: ${REGISTRY_BASE_URL}
         ENV_TYPE: ${ENV_TYPE}
         BAP_FINDER_FEE_TYPE: ${BAP_FINDER_FEE_TYPE}


### PR DESCRIPTION
# I have verified that NODE_DEV is not being used in anywhere in code. Clearly its a typo for NODE_ENV.


![image](https://github.com/hanabitech/ondc-sdk/assets/148043357/6a40ddd9-7c2e-4182-a9c0-9d77d65d5f94)

![image](https://github.com/hanabitech/ondc-sdk/assets/148043357/201c501c-ca11-4637-bc9d-25397628b1a9)
