### PR TITLE
[LB-416] Deploy docker-compose.yaml to have EXPECTED_RESPONSE_TIME in py-protocol-layer

### DIFF
--- a/docker-compose-for-local.yaml
+++ b/docker-compose-for-local.yaml
@@ -138,6 +138,7 @@ services:
       VOLUME_IMAGES_BASE_URL: ${VOLUME_IMAGES_BASE_URL}
       LOG_LEVEL: ${LOG_LEVEL}
       SELECTED_ISSUE_CRM: ${SELECTED_ISSUE_CRM}
+      FIREBASE_ADMIN_SERVICE_ACCOUNT: ${FIREBASE_ADMIN_SERVICE_ACCOUNT}
     container_name: biap-igm-node-js
     ports:
       - "8989:6969"
@@ -175,6 +176,7 @@ services:
       RABBITMQ_HOST: ${RABBITMQ_HOST}
       FLASK_SERVER: "True"
       QUEUE_ENABLE: "True"
+      EXPECTED_RESPONSE_TIME: ${EXPECTED_RESPONSE_TIME}
     ports:
       - 5555:5555
     expose:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -60,7 +60,7 @@ services:
   #     - ./data/certbot/www:/var/www/certbot
 
   ondc-cron-jobs:
-    build: 
+    build:
       context: ondc-cron-jobs
       dockerfile: Dockerfile
     environment:
@@ -179,6 +179,7 @@ services:
       RABBITMQ_HOST: ${RABBITMQ_HOST}
       FLASK_SERVER: "True"
       QUEUE_ENABLE: "True"
+      EXPECTED_RESPONSE_TIME: ${EXPECTED_RESPONSE_TIME}
     ports:
       - 5555:5555
     expose:


### PR DESCRIPTION
# Note
Came across this bug while implementing on_issue API, later when checked logs and found that protocol layer was unable to read EXPECTED_RESPONSE_TIME

<img width="1456" alt="Screenshot 2024-10-01 at 19 51 58" src="https://github.com/user-attachments/assets/00564240-7948-4ac6-99e6-ea7da6438e39">
